### PR TITLE
ClearLayer for Quests. Prevent map crash.

### DIFF
--- a/index.php
+++ b/index.php
@@ -201,6 +201,8 @@
 				raids4.clearLayers();
 				raids5.clearLayers();
 				getRaids();
+				questpoke.clearLayers();
+				questitem.clearLayers();
 				getQuestPoke();
 				timeOut=setTimeout("updateRaids()",60000);
 			}


### PR DESCRIPTION
By clearing the layer before loading the new layer. The map won't slow down over time.